### PR TITLE
fix: incorrect env var names

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -23,7 +23,7 @@ type action struct {
 }
 
 func (a *action) Cleanup(ctx context.Context, resourceGroupPattern string, commit bool) error {
-	Log("cleaning up resource groups with pattern %s", resourceGroupPattern)
+	Log("cleaning up resource groups with pattern %s (commit=%t)", resourceGroupPattern, commit)
 
 	LogDebug("Getting list of Azure resource groups")
 	pager := a.client.NewListPager(nil)

--- a/action/input.go
+++ b/action/input.go
@@ -8,11 +8,11 @@ import (
 )
 
 type Input struct {
-	ResourceGroupPattern string `env:"INPUT_RESOURCE_GROUPS"`
-	AzureSubscriptionID  string `env:"INPUT_SUBSCRIPTION_ID"`
-	AzureClientID        string `env:"INPUT_CLIENT_ID"`
-	AzureClientSecret    string `env:"INPUT_CLIENT_SECRET"`
-	AzureTenantID        string `env:"INPUT_TENANT_ID"`
+	ResourceGroupPattern string `env:"INPUT_RESOURCE-GROUPS"`
+	AzureSubscriptionID  string `env:"INPUT_SUBSCRIPTION-ID"`
+	AzureClientID        string `env:"INPUT_CLIENT-ID"`
+	AzureClientSecret    string `env:"INPUT_CLIENT-SECRET"`
+	AzureTenantID        string `env:"INPUT_TENANT-ID"`
 	Commit               bool   `env:"INPUT_COMMIT"`
 }
 


### PR DESCRIPTION
This fixes an issue where we where using the wrong env var names on the input struct.

As can be seen from the ouput of a run

```
/usr/bin/docker run --name ghcrioranchersandboxazurejanitorv010_376de4 --label d4dff5 --workdir /github/workspace --rm -e "INPUT_RESOURCE-GROUPS" -e "INPUT_SUBSCRIPTION-ID" -e "INPUT_CLIENT-ID" -e "INPUT_CLIENT-SECRET" -e "INPUT_TENANT-ID"
```